### PR TITLE
Add a filter for empty IP addresses when extracting NETDEV address

### DIFF
--- a/main.go
+++ b/main.go
@@ -370,6 +370,9 @@ func (m *Modem) SetupNetDev(link netlink.Link) {
 		if i < 1 {
 			continue
 		}
+		if strings.Trim(tok, `"`) == "" {
+			continue
+		}
 		ip := asIpAddr(tok, true)
 		addr, err := netlink.ParseAddr(ip)
 		if err != nil {


### PR DESCRIPTION
This is simple change to filter out empty IP addresses. My module returns something along the lines of 5,"192.168.0.1","" , the last one gets resolved as ip "00/64" which returns an error later on. 